### PR TITLE
Update README.md for Windows systems \env\Scripts\activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,24 @@ The sdk works by first CONSTRUCTING a transaction, then SIGNING, then
 SUBMITTING the transaction to the DeSo blockchain (via node.deso.org
 or test.deso.org by default, though you can select your own nodes if you prefer).
 
-To get started, simply run the file and follow its instructions:
+To get started, simply run the file and follow its instructions.
+
+On Posix systems:
 ```
 python3 -m venv myenv
 
 source myenv/bin/activate
+
+pip install -r requirements.txt
+
+python3 deso_sdk.py
+```
+
+For Windows systems:
+```
+python3 -m venv myenv
+
+myenv\Scripts\activate
 
 pip install -r requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python3 -m venv myenv
 
 source myenv/bin/activate
 
-pip install -r requirements.txt
+pip install -r ..\requirements.txt
 
 python3 deso_sdk.py
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python3 -m venv myenv
 
 source myenv/bin/activate
 
-pip install -r ..\requirements.txt
+pip install -r requirements.txt
 
 python3 deso_sdk.py
 ```
@@ -27,7 +27,7 @@ python3 -m venv myenv
 
 myenv\Scripts\activate
 
-pip install -r requirements.txt
+pip install -r ..\requirements.txt
 
 python3 deso_sdk.py
 ```


### PR DESCRIPTION
On Windows system the instructions result in:

```
source myenv/bin/activate
```
> 'source' is not recognized as an internal or external command,
operable program or batch file.

As per documentation:
On Windows, the equivalent activate script is in the Scripts folder:
> \path\to\env\Scripts\activate
See: https://virtualenv.pypa.io/en/legacy/userguide.html#activate-script